### PR TITLE
Added cookie policy support

### DIFF
--- a/Source/Saml2.Authentication.Core/Configuration/Saml2Options.cs
+++ b/Source/Saml2.Authentication.Core/Configuration/Saml2Options.cs
@@ -22,7 +22,8 @@
                 Name = $"{Saml2Defaults.SessionKeyPrefix}.{Guid.NewGuid():N}",
                 HttpOnly = true,
                 SameSite = SameSiteMode.None,
-                SecurePolicy = CookieSecurePolicy.SameAsRequest
+                SecurePolicy = CookieSecurePolicy.SameAsRequest,
+                IsEssential = true
             };
         }
 


### PR DESCRIPTION
When the cookie policy is used, a contest policy check can remove Saml2.Session cookie.  In this case, "IsEssential = true" should be set to bypass the contest policy check.