### PR TITLE
Added BuildResponseUrl method

### DIFF
--- a/Source/Saml2.Authentication.Core/Bindings/HttpRedirectBinding.cs
+++ b/Source/Saml2.Authentication.Core/Bindings/HttpRedirectBinding.cs
@@ -141,7 +141,7 @@ namespace Saml2.Authentication.Core.Bindings
         public string BuildLogoutResponseUrl(string providerName, Core.Saml2LogoutResponse logoutResponse, string relayState)
         {
             var response = logoutResponse.GetXml().OuterXml;
-            return BuildRequestUrl(providerName, relayState, response, logoutResponse.Destination);
+            return BuildResponseUrl(providerName, relayState, response, logoutResponse.Destination);
         }
 
         public string GetLogoutResponseMessage(string providerName)
@@ -244,6 +244,15 @@ namespace Saml2.Authentication.Core.Bindings
         {
             var result = new StringBuilder();
             result.AddMessageParameter(message, null);
+            result.AddRelayState(message, relayState);
+            AddSignature(providerName, result);
+            return $"{destination}?{result}";
+        }
+
+        private string BuildResponseUrl(string providerName, string relayState, string message, string destination)
+        {
+            var result = new StringBuilder();
+            result.AddMessageParameter(null, message);
             result.AddRelayState(message, relayState);
             AddSignature(providerName, result);
             return $"{destination}?{result}";


### PR DESCRIPTION
Added BuildResponseUrl method to HttpRedirectBinding.BuildLogoutResponseUrl to create correct response url for IDP initiated logout